### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/internal/server/static/main.ts
+++ b/internal/server/static/main.ts
@@ -52,7 +52,7 @@ function applyToRotations(index: number, fn: (node: HTMLElement) => void): void 
 const params = new URLSearchParams(window.location.search)
 const nParam = params.get("n")
 
-document.querySelectorAll("#number").forEach(x => x.innerHTML = nParam ?? "")
+document.querySelectorAll("#number").forEach(x => x.textContent = nParam ?? "")
 
 const gridSize = Number(nParam)
 const required = (gridSize * gridSize - gridSize % 2) / 4


### PR DESCRIPTION
Potential fix for [https://github.com/ItakawaM/arcipher/security/code-scanning/1](https://github.com/ItakawaM/arcipher/security/code-scanning/1)

Use a safe DOM sink for plain text instead of `innerHTML`. Since this code only needs to display the value, `textContent` is the best drop-in fix and preserves functionality (showing the query value) without parsing it as HTML.

Best single fix in `internal/server/static/main.ts`:
- Replace line 55 assignment from `x.innerHTML = nParam ?? ""` to `x.textContent = nParam ?? ""`.
- No new imports, helpers, or dependencies are needed.

This removes the XSS vector while keeping visible output behavior equivalent for normal text/numeric values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
